### PR TITLE
Added missing packages to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,23 @@ RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 ARG SWAGGER_UI_VERSION=3.20.9
 
 RUN go get -d -v github.com/go-swagger/go-swagger \
+    && go get github.com/go-openapi/analysis \
+    && go get github.com/go-openapi/inflect \
+    && go get github.com/go-openapi/loads \
+    && go get github.com/go-openapi/spec \
+    && go get github.com/go-openapi/validate \
+    && go get github.com/gorilla/context \
+    && go get github.com/gorilla/handlers \
+    && go get github.com/jessevdk/go-flags \
+    && go get github.com/kr/pretty \
+    && go get github.com/pkg/errors \
+    && go get github.com/spf13/viper \
+    && go get github.com/toqueteos/webbrowser \
+    && go get github.com/tylerb/graceful \
+    && go get golang.org/x/net/context \
+    && go get golang.org/x/tools/go/ast/astutil \
+    && go get golang.org/x/tools/go/packages \
+    && go get golang.org/x/tools/imports \ 
     && go install github.com/go-swagger/go-swagger/cmd/swagger \
     && curl -sfL https://github.com/swagger-api/swagger-ui/archive/v$SWAGGER_UI_VERSION.tar.gz | tar xz -C /tmp/ \
     && mv /tmp/swagger-ui-$SWAGGER_UI_VERSION /tmp/swagger \


### PR DESCRIPTION
### Description

Added the missing packages in Dockerfile:

    && go get github.com/go-openapi/analysis \
    && go get github.com/go-openapi/inflect \
    && go get github.com/go-openapi/loads \
    && go get github.com/go-openapi/spec \
    && go get github.com/go-openapi/validate \
    && go get github.com/gorilla/context \
    && go get github.com/gorilla/handlers \
    && go get github.com/jessevdk/go-flags \
    && go get github.com/kr/pretty \
    && go get github.com/pkg/errors \
    && go get github.com/spf13/viper \
    && go get github.com/toqueteos/webbrowser \
    && go get github.com/tylerb/graceful \
    && go get golang.org/x/net/context \
    && go get golang.org/x/tools/go/ast/astutil \
    && go get golang.org/x/tools/go/packages \
    && go get golang.org/x/tools/imports \ 
