### PR TITLE
Update app doc to include prebuild docker image in Github Packages

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -123,6 +123,15 @@ To build a docker image with the application installed on it
 
 `docker build . -t techtestapp:latest`
 
+
+### Pull Image from Github packages
+
+Go to the [packages](https://github.com/servian/TechTestApp/packages) section for an already built docker image. 
+To pull a ready built docker image with the application installed on it, [setup](https://docs.github.com/en/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages) docker to auth to Github then:
+
+`docker pull docker.pkg.github.com/servian/techtestapp/techtestapp:latest`
+
+
 ## Continuous Integration
 
 Continuous integration is managed through circleci and the build on the master branch will create a new release when a new version is defined.


### PR DESCRIPTION
### Description

I've updated the app docs to include a pointer to Github Packages docker build and how folks can pull the image. 

Thanks to @tristanmorgan for pushing the image

Fixes: No issue was raised, for folks that didn't want to go down building the docker image themselves.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added issue number to `Fixes` line above


FYI @TWinsnes @andrewpym-servian 